### PR TITLE
fix the version problems of software

### DIFF
--- a/graph-accelerator/pom.xml
+++ b/graph-accelerator/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-graphx_2.11</artifactId>
-      <version>2.4.6</version>
+      <version>2.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark.graphx.lib</groupId>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-mllib_2.11</artifactId>
-      <version>2.4.6</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/graph-core/pom.xml
+++ b/graph-core/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-graphx_2.11</artifactId>
-            <version>2.4.6</version>
+            <version>2.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_2.11</artifactId>
-            <version>2.4.6</version>
+            <version>2.3.2</version>
         </dependency>
     </dependencies>
 

--- a/graph-kernel/pom.xml
+++ b/graph-kernel/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-graphx_2.11</artifactId>
-      <version>2.4.6</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <encoding>UTF-8</encoding>
-	    <spark.version>spark2.4.6</spark.version>
+	    <spark.version>spark2.3.2</spark.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Changed the Spark dependence version of master branch from spark 2.4.6 to spark 2.3.2. 
Now the master branch is based on Spark2.3.2 and the Spark2.4.6 branch is based on Spark2.4.6